### PR TITLE
Log non-queueing worker exceptions

### DIFF
--- a/src/SlmQueueBeanstalkd/Worker/BeanstalkdWorker.php
+++ b/src/SlmQueueBeanstalkd/Worker/BeanstalkdWorker.php
@@ -32,6 +32,9 @@ class BeanstalkdWorker extends AbstractWorker
         } catch (JobException\BuryableException $exception) {
             $queue->bury($job, $exception->getOptions());
         } catch (Exception $exception) {
+            error_log('BeanstalkdWorker->processJob() unexpected exception:', 0);
+            error_log($exception->getMessage(), 0);
+            error_log($exception->getPrevious(), 0);            
             $queue->bury($job, array('priority' => Pheanstalk::DEFAULT_PRIORITY));
         }
     }


### PR DESCRIPTION
Jobs may end being buried because of an exception thrown by some other module (like PDO) and no info about it is being saved right now so it is hard to find out why the job has been buried.
