### PR TITLE
Custom tube names in Beanstalkd for queues

### DIFF
--- a/config/slm_queue_beanstalkd.local.php.dist
+++ b/config/slm_queue_beanstalkd.local.php.dist
@@ -11,12 +11,6 @@ return array(
          * Configuration for Beanstalkd
          */
         'beanstalkd' => array(
-            /**
-             * Beanstalkd tubes that should be used for queues
-             */
-            'tubes' => array(
-                // 'my-queue' => 'beanstalkd-tube-for-my-queue'
-            ),
             'connection' => array(
                 /**
                  * Connection host
@@ -35,5 +29,12 @@ return array(
                 // 'timeout' => 2
             ),
         ),
+        /**
+         * Beanstalkd tubes that should be used for queues
+         */
+        'queues' => array(
+            // 'my-queue' => array('tube' => 'beanstalkd-tube-for-my-queue'),
+        ),
+
     ),
 );

--- a/config/slm_queue_beanstalkd.local.php.dist
+++ b/config/slm_queue_beanstalkd.local.php.dist
@@ -11,6 +11,12 @@ return array(
          * Configuration for Beanstalkd
          */
         'beanstalkd' => array(
+            /**
+             * Beanstalkd tubes that should be used for queues
+             */
+            'tubes' => array(
+                // 'my-queue' => 'beanstalkd-tube-for-my-queue'
+            ),
             'connection' => array(
                 /**
                  * Connection host

--- a/src/SlmQueueBeanstalkd/Factory/BeanstalkdQueueFactory.php
+++ b/src/SlmQueueBeanstalkd/Factory/BeanstalkdQueueFactory.php
@@ -2,6 +2,7 @@
 
 namespace SlmQueueBeanstalkd\Factory;
 
+use SlmQueueBeanstalkd\Options\QueueOptions;
 use SlmQueueBeanstalkd\Queue\BeanstalkdQueue;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
@@ -20,13 +21,23 @@ class BeanstalkdQueueFactory implements FactoryInterface
         $pheanstalk       = $parentLocator->get('SlmQueueBeanstalkd\Service\PheanstalkService');
         $jobPluginManager = $parentLocator->get('SlmQueue\Job\JobPluginManager');
 
-        //Getting beanstalkd tube name
-        /** @var $beanstalkdOptions \SlmQueueBeanstalkd\Options\BeanstalkdOptions */
-        $beanstalkdOptions = $parentLocator->get('SlmQueueBeanstalkd\Options\BeanstalkdOptions');
-        $tubes = $beanstalkdOptions->getTubes();
-        $tubeName = (empty($tubes[$requestedName])? null : $tubes[$requestedName]);
+        $queueOptions = $this->getQueueOptions($parentLocator, $requestedName);
 
-        return new BeanstalkdQueue($pheanstalk, $requestedName, $jobPluginManager, $tubeName);
+        return new BeanstalkdQueue($pheanstalk, $requestedName, $jobPluginManager, $queueOptions);
     }
 
+    /**
+     * Returns custom beanstalkd options for specified queue
+     * @param ServiceLocatorInterface $serviceLocator
+     * @param string $queueName
+     * @return QueueOptions
+     */
+    protected function getQueueOptions(ServiceLocatorInterface $serviceLocator, $queueName)
+    {
+        $config = $serviceLocator->get('Config');
+        $queuesOptions = isset($config['slm_queue']['queues'])? $config['slm_queue']['queues'] : array();
+        $queueOptions = isset($queuesOptions[$queueName])? $queuesOptions[$queueName] : array();
+
+        return new QueueOptions($queueOptions);
+    }
 }

--- a/src/SlmQueueBeanstalkd/Factory/BeanstalkdQueueFactory.php
+++ b/src/SlmQueueBeanstalkd/Factory/BeanstalkdQueueFactory.php
@@ -20,6 +20,13 @@ class BeanstalkdQueueFactory implements FactoryInterface
         $pheanstalk       = $parentLocator->get('SlmQueueBeanstalkd\Service\PheanstalkService');
         $jobPluginManager = $parentLocator->get('SlmQueue\Job\JobPluginManager');
 
-        return new BeanstalkdQueue($pheanstalk, $requestedName, $jobPluginManager);
+        //Getting beanstalkd tube name
+        /** @var $beanstalkdOptions \SlmQueueBeanstalkd\Options\BeanstalkdOptions */
+        $beanstalkdOptions = $parentLocator->get('SlmQueueBeanstalkd\Options\BeanstalkdOptions');
+        $tubes = $beanstalkdOptions->getTubes();
+        $tubeName = (empty($tubes[$requestedName])? null : $tubes[$requestedName]);
+
+        return new BeanstalkdQueue($pheanstalk, $requestedName, $jobPluginManager, $tubeName);
     }
+
 }

--- a/src/SlmQueueBeanstalkd/Options/BeanstalkdOptions.php
+++ b/src/SlmQueueBeanstalkd/Options/BeanstalkdOptions.php
@@ -15,11 +15,6 @@ class BeanstalkdOptions extends AbstractOptions
     protected $connection;
 
     /**
-     * @var array
-     */
-    protected $tubes = [];
-
-    /**
      * Set the connection options
      *
      * @param array $options
@@ -37,23 +32,5 @@ class BeanstalkdOptions extends AbstractOptions
     public function getConnection()
     {
         return $this->connection;
-    }
-
-    /**
-     * Set beanstalkd tube names to use for queues
-     * @param array $tubes
-     */
-    public function setTubes(array $tubes)
-    {
-        $this->tubes = $tubes;
-    }
-
-    /**
-     * Get beanstalkd tube names to use for queues
-     * @return array
-     */
-    public function getTubes()
-    {
-        return $this->tubes;
     }
 }

--- a/src/SlmQueueBeanstalkd/Options/BeanstalkdOptions.php
+++ b/src/SlmQueueBeanstalkd/Options/BeanstalkdOptions.php
@@ -14,6 +14,10 @@ class BeanstalkdOptions extends AbstractOptions
      */
     protected $connection;
 
+    /**
+     * @var array
+     */
+    protected $tubes = [];
 
     /**
      * Set the connection options
@@ -33,5 +37,23 @@ class BeanstalkdOptions extends AbstractOptions
     public function getConnection()
     {
         return $this->connection;
+    }
+
+    /**
+     * Set beanstalkd tube names to use for queues
+     * @param array $tubes
+     */
+    public function setTubes(array $tubes)
+    {
+        $this->tubes = $tubes;
+    }
+
+    /**
+     * Get beanstalkd tube names to use for queues
+     * @return array
+     */
+    public function getTubes()
+    {
+        return $this->tubes;
     }
 }

--- a/src/SlmQueueBeanstalkd/Options/QueueOptions.php
+++ b/src/SlmQueueBeanstalkd/Options/QueueOptions.php
@@ -9,7 +9,7 @@ class QueueOptions extends AbstractOptions
     /**
      * @var string
      */
-    protected $tube;
+    protected $tube = '';
 
     /**
      * Get beanstalkd tube name for queue

--- a/src/SlmQueueBeanstalkd/Options/QueueOptions.php
+++ b/src/SlmQueueBeanstalkd/Options/QueueOptions.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SlmQueueBeanstalkd\Options;
+
+use Zend\Stdlib\AbstractOptions;
+
+class QueueOptions extends AbstractOptions
+{
+    /**
+     * @var string
+     */
+    protected $tube;
+
+    /**
+     * Get beanstalkd tube name for queue
+     * @return string
+     */
+    public function getTube()
+    {
+        return $this->tube;
+    }
+
+    /**
+     * Set beanstalkd tube for queue
+     * @param string $tube
+     */
+    public function setTube($tube)
+    {
+        $this->tube = $tube;
+    }
+}

--- a/src/SlmQueueBeanstalkd/Queue/BeanstalkdQueue.php
+++ b/src/SlmQueueBeanstalkd/Queue/BeanstalkdQueue.php
@@ -35,8 +35,7 @@ class BeanstalkdQueue extends AbstractQueue implements BeanstalkdQueueInterface
     {
         $this->pheanstalk = $pheanstalk;
         $this->tubeName = $name;
-        if (($options !== null) && (!empty($options->getTube())))
-        {
+        if (($options !== null) && $options->getTube()) {
             $this->tubeName = $options->getTube();
         }
         parent::__construct($name, $jobPluginManager);

--- a/src/SlmQueueBeanstalkd/Queue/BeanstalkdQueue.php
+++ b/src/SlmQueueBeanstalkd/Queue/BeanstalkdQueue.php
@@ -31,8 +31,12 @@ class BeanstalkdQueue extends AbstractQueue implements BeanstalkdQueueInterface
      * @param string           $name
      * @param JobPluginManager $jobPluginManager
      */
-    public function __construct(Pheanstalk $pheanstalk, $name, JobPluginManager $jobPluginManager, QueueOptions $options = null)
-    {
+    public function __construct(
+        Pheanstalk $pheanstalk,
+        $name,
+        JobPluginManager $jobPluginManager,
+        QueueOptions $options = null
+    ) {
         $this->pheanstalk = $pheanstalk;
         $this->tubeName = $name;
         if (($options !== null) && $options->getTube()) {

--- a/src/SlmQueueBeanstalkd/Queue/BeanstalkdQueue.php
+++ b/src/SlmQueueBeanstalkd/Queue/BeanstalkdQueue.php
@@ -7,6 +7,7 @@ use Pheanstalk\Pheanstalk;
 use SlmQueue\Job\JobInterface;
 use SlmQueue\Job\JobPluginManager;
 use SlmQueue\Queue\AbstractQueue;
+use SlmQueueBeanstalkd\Options\QueueOptions;
 
 /**
  * BeanstalkdQueue
@@ -30,10 +31,14 @@ class BeanstalkdQueue extends AbstractQueue implements BeanstalkdQueueInterface
      * @param string           $name
      * @param JobPluginManager $jobPluginManager
      */
-    public function __construct(Pheanstalk $pheanstalk, $name, JobPluginManager $jobPluginManager, $tubeName = null)
+    public function __construct(Pheanstalk $pheanstalk, $name, JobPluginManager $jobPluginManager, QueueOptions $options = null)
     {
         $this->pheanstalk = $pheanstalk;
-        $this->tubeName = (empty($tubeName)? $name : $tubeName);
+        $this->tubeName = $name;
+        if (($options !== null) && (!empty($options->getTube())))
+        {
+            $this->tubeName = $options->getTube();
+        }
         parent::__construct($name, $jobPluginManager);
     }
 

--- a/tests/SlmQueueBeanstalkdTest/Queue/BeanstalkdQueueTubeTest.php
+++ b/tests/SlmQueueBeanstalkdTest/Queue/BeanstalkdQueueTubeTest.php
@@ -4,6 +4,7 @@ namespace SlmQueueBeanstalkdTest\Queue;
 
 use Pheanstalk\Job as PheanstalkJob;
 use PHPUnit_Framework_TestCase as TestCase;
+use SlmQueueBeanstalkd\Options\QueueOptions;
 use SlmQueueBeanstalkd\Queue\BeanstalkdQueue;
 use SlmQueueBeanstalkdTest\Asset\SimpleJob;
 
@@ -45,7 +46,10 @@ class BeanstalkdQueueTubeTest extends TestCase
                                     ->disableOriginalConstructor()
                                     ->getMock();
 
-        $this->queue = new BeanstalkdQueue($this->pheanstalk, $this->queueName, $this->pluginManager, $this->tubeName);
+        $queueOptions = new QueueOptions();
+        $queueOptions->setTube($this->tubeName);
+
+        $this->queue = new BeanstalkdQueue($this->pheanstalk, $this->queueName, $this->pluginManager, $queueOptions);
     }
 
     public function testTubeNameGetter()


### PR DESCRIPTION
I really miss this feature because for my application there are two environments (dev and demo) that use same Beanstalkd server. There are possible workarounds for this situation like using different queues or additional fields for job payload but I believe that separating queue name from tube name is a better solution. 