### PR TITLE
Support for ZF3 and slm/queue v1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,52 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
+  - 7.1
+
+env:
+  global:
+    - COMPOSER_ARGS="--no-interaction"
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.3
+      env:
+        - DEPS=lowest
+    - php: 5.3
+      env:
+        - DEPS=latest
+    - php: 5.4
+      env:
+        - DEPS=lowest
+    - php: 5.4
+      env:
+        - DEPS=latest
+    - php: 5.5
+      env:
+        - DEPS=lowest
+    - php: 5.5
+      env:
+        - DEPS=latest
+    - php: 5.6
+      env:
+        - DEPS=lowest
+    - php: 5.6
+      env:
+        - DEPS=latest
+    - php: 7.0
+      env:
+        - DEPS=lowest
+    - php: 7.0
+      env:
+        - DEPS=latest
+    - php: 7.1
+      env:
+        - DEPS=lowest
+    - php: 7.1
+      env:
+        - DEPS=latest
 
 before_script:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,5 @@
 language: php
 
-php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-
 env:
   global:
     - COMPOSER_ARGS="--no-interaction"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.3
-      env:
-        - DEPS=lowest
-    - php: 5.3
-      env:
-        - DEPS=latest
-    - php: 5.4
-      env:
-        - DEPS=lowest
-    - php: 5.4
       env:
         - DEPS=latest
     - php: 5.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ env:
 matrix:
   fast_finish: true
   include:
-      env:
-        - DEPS=latest
     - php: 5.5
       env:
         - DEPS=lowest

--- a/composer.json
+++ b/composer.json
@@ -1,53 +1,57 @@
 {
-    "name": "slm/queue-beanstalkd",
-    "description": "Zend Framework 2 module that integrates with Beanstalkd queuing system",
-    "license": "BSD-3-Clause",
-    "type": "library",
-    "keywords": [
-        "zf2",
-        "queue",
-        "job",
-        "beanstalk",
-        "beanstalkd",
-        "pheanstalk"
-    ],
-    "homepage": "https://github.com/juriansluiman/SlmQueueBeanstalkd",
-    "authors": [
-        {
-            "name": "Jurian Sluiman",
-            "email": "jurian@juriansluiman.nl",
-            "homepage": "http://juriansluiman.nl"
-        },
-        {
-            "name": "Michaël Gallego",
-            "email": "mic.gallego@gmail.com",
-            "homepage": "http://www.michaelgallego.fr"
-        }
-    ],
-    "require": {
-        "php": ">=5.3.3",
-        "zendframework/zend-mvc": "~2.2",
-        "zendframework/zend-servicemanager": "~2.2",
-        "zendframework/zend-stdlib": "~2.2",
-        "slm/queue": "0.4.*",
-        "pda/pheanstalk": "~3.0"
+  "name": "slm/queue-beanstalkd",
+  "description": "Zend Framework 2 module that integrates with Beanstalkd queuing system",
+  "license": "BSD-3-Clause",
+  "type": "library",
+  "keywords": [
+    "zf2",
+    "queue",
+    "job",
+    "beanstalk",
+    "beanstalkd",
+    "pheanstalk"
+  ],
+  "homepage": "https://github.com/juriansluiman/SlmQueueBeanstalkd",
+  "authors": [
+    {
+      "name": "Jurian Sluiman",
+      "email": "jurian@juriansluiman.nl",
+      "homepage": "http://juriansluiman.nl"
     },
-    "require-dev": {
-        "zendframework/zendframework": "~2.2",
-        "squizlabs/php_codesniffer": "1.5.*",
-        "phpunit/phpunit": "~4.1"
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "0.4.x-dev"
-        }
-    },
-    "autoload": {
-        "psr-0": {
-            "SlmQueueBeanstalkd": "src/"
-        },
-        "classmap": [
-            "./Module.php"
-        ]
+    {
+      "name": "Michaël Gallego",
+      "email": "mic.gallego@gmail.com",
+      "homepage": "http://www.michaelgallego.fr"
     }
+  ],
+  "require": {
+    "php": ">=5.3.3",
+    "zendframework/zend-mvc": "~2.2",
+    "zendframework/zend-config": "^2.5",
+    "zendframework/zend-servicemanager": "^2.7.4 || ^3.0",
+    "slm/queue": "^1.0",
+    "pda/pheanstalk": "~3.0"
+  },
+  "require-dev": {
+    "zendframework/zend-modulemanager": "^2.5",
+    "zendframework/zend-serializer": "^2.5",
+    "zendframework/zend-i18n": "^2.5",
+    "zendframework/zend-log": "^2.5",
+    "zendframework/zend-view": "^2.5",
+    "squizlabs/php_codesniffer": "1.5.*",
+    "phpunit/phpunit": "~4.1"
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-master": "0.4.x-dev"
+    }
+  },
+  "autoload": {
+    "psr-0": {
+      "SlmQueueBeanstalkd": "src/"
+    },
+    "classmap": [
+      "./Module.php"
+    ]
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     }
   ],
   "require": {
-    "php": ">=5.3.3",
+    "php": ">=5.5",
     "zendframework/zend-mvc": "~2.2",
     "zendframework/zend-config": "^2.5",
     "zendframework/zend-servicemanager": "^2.7.4 || ^3.0",

--- a/composer.json
+++ b/composer.json
@@ -1,57 +1,57 @@
 {
-  "name": "slm/queue-beanstalkd",
-  "description": "Zend Framework 2 module that integrates with Beanstalkd queuing system",
-  "license": "BSD-3-Clause",
-  "type": "library",
-  "keywords": [
-    "zf2",
-    "queue",
-    "job",
-    "beanstalk",
-    "beanstalkd",
-    "pheanstalk"
-  ],
-  "homepage": "https://github.com/juriansluiman/SlmQueueBeanstalkd",
-  "authors": [
-    {
-      "name": "Jurian Sluiman",
-      "email": "jurian@juriansluiman.nl",
-      "homepage": "http://juriansluiman.nl"
+    "name": "slm/queue-beanstalkd",
+    "description": "Zend Framework 2 module that integrates with Beanstalkd queuing system",
+    "license": "BSD-3-Clause",
+    "type": "library",
+    "keywords": [
+        "zf2",
+        "queue",
+        "job",
+        "beanstalk",
+        "beanstalkd",
+        "pheanstalk"
+    ],
+    "homepage": "https://github.com/juriansluiman/SlmQueueBeanstalkd",
+    "authors": [
+        {
+            "name": "Jurian Sluiman",
+            "email": "jurian@juriansluiman.nl",
+            "homepage": "http://juriansluiman.nl"
+        },
+        {
+            "name": "Michaël Gallego",
+            "email": "mic.gallego@gmail.com",
+            "homepage": "http://www.michaelgallego.fr"
+        }
+    ],
+    "require": {
+        "php": ">=5.5",
+        "zendframework/zend-mvc": "~2.2",
+        "zendframework/zend-config": "^2.5",
+        "zendframework/zend-servicemanager": "^2.7.4 || ^3.0",
+        "slm/queue": "^1.0",
+        "pda/pheanstalk": "~3.0"
     },
-    {
-      "name": "Michaël Gallego",
-      "email": "mic.gallego@gmail.com",
-      "homepage": "http://www.michaelgallego.fr"
-    }
-  ],
-  "require": {
-    "php": ">=5.5",
-    "zendframework/zend-mvc": "~2.2",
-    "zendframework/zend-config": "^2.5",
-    "zendframework/zend-servicemanager": "^2.7.4 || ^3.0",
-    "slm/queue": "^1.0",
-    "pda/pheanstalk": "~3.0"
-  },
-  "require-dev": {
-    "zendframework/zend-modulemanager": "^2.5",
-    "zendframework/zend-serializer": "^2.5",
-    "zendframework/zend-i18n": "^2.5",
-    "zendframework/zend-log": "^2.5",
-    "zendframework/zend-view": "^2.5",
-    "squizlabs/php_codesniffer": "1.5.*",
-    "phpunit/phpunit": "~4.1"
-  },
-  "extra": {
-    "branch-alias": {
-      "dev-master": "0.4.x-dev"
-    }
-  },
-  "autoload": {
-    "psr-0": {
-      "SlmQueueBeanstalkd": "src/"
+    "require-dev": {
+        "zendframework/zend-modulemanager": "^2.5",
+        "zendframework/zend-serializer": "^2.5",
+        "zendframework/zend-i18n": "^2.5",
+        "zendframework/zend-log": "^2.5",
+        "zendframework/zend-view": "^2.5",
+        "squizlabs/php_codesniffer": "1.5.*",
+        "phpunit/phpunit": "~4.1"
     },
-    "classmap": [
-      "./Module.php"
-    ]
-  }
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.4.x-dev"
+        }
+    },
+    "autoload": {
+        "psr-0": {
+            "SlmQueueBeanstalkd": "src/"
+        },
+        "classmap": [
+            "./Module.php"
+        ]
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     ],
     "require": {
         "php": ">=5.5",
-        "zendframework/zend-mvc": "~2.2",
+        "zendframework/zend-mvc": "^2.2 || ^3.0",
         "zendframework/zend-config": "^2.5",
         "zendframework/zend-servicemanager": "^2.7.4 || ^3.0",
         "slm/queue": "^1.0",

--- a/src/SlmQueueBeanstalkd/Factory/BeanstalkdOptionsFactory.php
+++ b/src/SlmQueueBeanstalkd/Factory/BeanstalkdOptionsFactory.php
@@ -2,18 +2,29 @@
 
 namespace SlmQueueBeanstalkd\Factory;
 
+use Interop\Container\ContainerInterface;
 use SlmQueueBeanstalkd\Options\BeanstalkdOptions;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 class BeanstalkdOptionsFactory implements FactoryInterface
 {
+
     /**
      * {@inheritDoc}
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $config = $serviceLocator->get('Config');
+        return $this($serviceLocator, BeanstalkdOptions::class);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        $config = $container->get('Config');
+
         return new BeanstalkdOptions($config['slm_queue']['beanstalkd']);
     }
 }

--- a/src/SlmQueueBeanstalkd/Factory/BeanstalkdQueueFactory.php
+++ b/src/SlmQueueBeanstalkd/Factory/BeanstalkdQueueFactory.php
@@ -19,7 +19,12 @@ class BeanstalkdQueueFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        return $this($serviceLocator, BeanstalkdQueue::class);
+        $container = $serviceLocator;
+        if (method_exists($container, 'getServiceLocator')) {
+            $container = $container->getServiceLocator() ?: $container;
+        }
+        
+        return $this($container, BeanstalkdQueue::class);
     }
 
 
@@ -41,14 +46,10 @@ class BeanstalkdQueueFactory implements FactoryInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritDoc}
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        if (method_exists($container, 'getServiceLocator')) {
-            $container = $container->getServiceLocator() ?: $container;
-        }
-
         $pheanstalk       = $container->get('SlmQueueBeanstalkd\Service\PheanstalkService');
         $jobPluginManager = $container->get('SlmQueue\Job\JobPluginManager');
 

--- a/src/SlmQueueBeanstalkd/Factory/BeanstalkdQueueFactory.php
+++ b/src/SlmQueueBeanstalkd/Factory/BeanstalkdQueueFactory.php
@@ -26,8 +26,8 @@ class BeanstalkdQueueFactory implements FactoryInterface
     /**
      * Returns custom beanstalkd options for specified queue
      *
-     * @param ServiceLocatorInterface $serviceLocator
-     * @param string                  $queueName
+     * @param ContainerInterface $serviceLocator
+     * @param string $queueName
      *
      * @return QueueOptions
      */

--- a/src/SlmQueueBeanstalkd/Factory/BeanstalkdWorkerControllerFactory.php
+++ b/src/SlmQueueBeanstalkd/Factory/BeanstalkdWorkerControllerFactory.php
@@ -2,6 +2,7 @@
 
 namespace SlmQueueBeanstalkd\Factory;
 
+use Interop\Container\ContainerInterface;
 use SlmQueueBeanstalkd\Controller\BeanstalkdWorkerController;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
@@ -16,8 +17,20 @@ class BeanstalkdWorkerControllerFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $worker  = $serviceLocator->getServiceLocator()->get('SlmQueueBeanstalkd\Worker\BeanstalkdWorker');
-        $manager = $serviceLocator->getServiceLocator()->get('SlmQueue\Queue\QueuePluginManager');
+        return $this($serviceLocator, BeanstalkdWorkerController::class);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        if (method_exists($container, 'getServiceLocator')) {
+            $container = $container->getServiceLocator() ?: $container;
+        }
+
+        $worker  = $container->get('SlmQueueBeanstalkd\Worker\BeanstalkdWorker');
+        $manager = $container->get('SlmQueue\Queue\QueuePluginManager');
 
         return new BeanstalkdWorkerController($worker, $manager);
     }

--- a/src/SlmQueueBeanstalkd/Factory/BeanstalkdWorkerControllerFactory.php
+++ b/src/SlmQueueBeanstalkd/Factory/BeanstalkdWorkerControllerFactory.php
@@ -17,7 +17,12 @@ class BeanstalkdWorkerControllerFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        return $this($serviceLocator, BeanstalkdWorkerController::class);
+        $container = $serviceLocator;
+        if (method_exists($container, 'getServiceLocator')) {
+            $container = $container->getServiceLocator() ?: $container;
+        }
+        
+        return $this($container, BeanstalkdWorkerController::class);
     }
 
     /**
@@ -25,10 +30,6 @@ class BeanstalkdWorkerControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        if (method_exists($container, 'getServiceLocator')) {
-            $container = $container->getServiceLocator() ?: $container;
-        }
-
         $worker  = $container->get('SlmQueueBeanstalkd\Worker\BeanstalkdWorker');
         $manager = $container->get('SlmQueue\Queue\QueuePluginManager');
 

--- a/src/SlmQueueBeanstalkd/Factory/PheanstalkFactory.php
+++ b/src/SlmQueueBeanstalkd/Factory/PheanstalkFactory.php
@@ -2,7 +2,9 @@
 
 namespace SlmQueueBeanstalkd\Factory;
 
+use Interop\Container\ContainerInterface;
 use Pheanstalk\Pheanstalk;
+use SlmQueueBeanstalkd\Options\BeanstalkdOptions;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
@@ -16,8 +18,15 @@ class PheanstalkFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
+        return $this($serviceLocator, Pheanstalk::class);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null) {
         /** @var $beanstalkdOptions \SlmQueueBeanstalkd\Options\BeanstalkdOptions */
-        $beanstalkdOptions = $serviceLocator->get('SlmQueueBeanstalkd\Options\BeanstalkdOptions');
+        $beanstalkdOptions = $container->get(BeanstalkdOptions::class);
         $connectionOptions = $beanstalkdOptions->getConnection();
 
         return new Pheanstalk(
@@ -25,5 +34,4 @@ class PheanstalkFactory implements FactoryInterface
             $connectionOptions->getPort(),
             $connectionOptions->getTimeout()
         );
-    }
-}
+}}

--- a/src/SlmQueueBeanstalkd/Factory/PheanstalkFactory.php
+++ b/src/SlmQueueBeanstalkd/Factory/PheanstalkFactory.php
@@ -13,6 +13,7 @@ use Zend\ServiceManager\ServiceLocatorInterface;
  */
 class PheanstalkFactory implements FactoryInterface
 {
+
     /**
      * {@inheritDoc}
      */
@@ -24,7 +25,8 @@ class PheanstalkFactory implements FactoryInterface
     /**
      * @inheritdoc
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null) {
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
         /** @var $beanstalkdOptions \SlmQueueBeanstalkd\Options\BeanstalkdOptions */
         $beanstalkdOptions = $container->get(BeanstalkdOptions::class);
         $connectionOptions = $beanstalkdOptions->getConnection();
@@ -34,4 +36,5 @@ class PheanstalkFactory implements FactoryInterface
             $connectionOptions->getPort(),
             $connectionOptions->getTimeout()
         );
-}}
+    }
+}

--- a/src/SlmQueueBeanstalkd/Worker/BeanstalkdWorker.php
+++ b/src/SlmQueueBeanstalkd/Worker/BeanstalkdWorker.php
@@ -6,7 +6,7 @@ use Exception;
 use SlmQueue\Job\JobInterface;
 use SlmQueue\Queue\QueueInterface;
 use SlmQueue\Worker\AbstractWorker;
-use SlmQueue\Worker\WorkerEvent;
+use SlmQueue\Worker\Event\ProcessJobEvent;
 use SlmQueueBeanstalkd\Queue\BeanstalkdQueueInterface;
 
 /**
@@ -20,7 +20,7 @@ class BeanstalkdWorker extends AbstractWorker
     public function processJob(JobInterface $job, QueueInterface $queue)
     {
         if (!$queue instanceof BeanstalkdQueueInterface) {
-            return WorkerEvent::JOB_STATUS_UNKNOWN;
+            return ProcessJobEvent::JOB_STATUS_UNKNOWN;
         }
 
         /**
@@ -33,10 +33,10 @@ class BeanstalkdWorker extends AbstractWorker
             $job->execute();
             $queue->delete($job);
 
-            return WorkerEvent::JOB_STATUS_SUCCESS;
+            return ProcessJobEvent::JOB_STATUS_SUCCESS;
         } catch (Exception $exception) {
             // Do nothing, the job will be reinserted automatically for another try
-            return WorkerEvent::JOB_STATUS_FAILURE_RECOVERABLE;
+            return ProcessJobEvent::JOB_STATUS_FAILURE_RECOVERABLE;
         }
     }
 }

--- a/tests/SlmQueueBeanstalkdTest/Controller/BeanstalkdWorkerControllerTest.php
+++ b/tests/SlmQueueBeanstalkdTest/Controller/BeanstalkdWorkerControllerTest.php
@@ -4,7 +4,8 @@ namespace SlmQueueBeanstalkdTest\Controller;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use SlmQueueBeanstalkd\Controller\BeanstalkdWorkerController;
-use Zend\Mvc\Router\RouteMatch;
+use Zend\Mvc\Router\RouteMatch as DeprecatedRouteMatch;
+use Zend\Router\RouteMatch;
 
 class BeanstalkdWorkerControllerTest extends TestCase
 {
@@ -21,7 +22,8 @@ class BeanstalkdWorkerControllerTest extends TestCase
 
         $controller    = new BeanstalkdWorkerController($worker, $pluginManager);
 
-        $routeMatch = new RouteMatch(array('queue' => 'newsletter'));
+        $routeMatch = $this->createRouteMatch();
+        $routeMatch->setParam('queue', 'newsletter');
         $controller->getEvent()->setRouteMatch($routeMatch);
 
         $worker->expects($this->once())
@@ -32,5 +34,14 @@ class BeanstalkdWorkerControllerTest extends TestCase
         $result = $controller->processAction();
 
         $this->assertStringEndsWith("One state\n", $result);
+    }
+
+    private function createRouteMatch()
+    {
+        if (class_exists(DeprecatedRouteMatch::class)) {
+            return new DeprecatedRouteMatch([]);
+        }
+
+        return new RouteMatch([]);
     }
 }

--- a/tests/SlmQueueBeanstalkdTest/Options/BeanstalkdOptionsTest.php
+++ b/tests/SlmQueueBeanstalkdTest/Options/BeanstalkdOptionsTest.php
@@ -3,6 +3,8 @@
 namespace SlmQueueBeanstalkdTest\Options;
 
 use PHPUnit_Framework_TestCase as TestCase;
+use SlmQueueBeanstalkd\Options\BeanstalkdOptions;
+use SlmQueueBeanstalkd\Options\ConnectionOptions;
 use SlmQueueBeanstalkdTest\Util\ServiceManagerFactory;
 use Zend\ServiceManager\ServiceManager;
 
@@ -22,11 +24,11 @@ class BeanstalkdOptionsTest extends TestCase
     public function testCreateBeanstalkdOptions()
     {
         /** @var $beanstalkdOptions \SlmQueueBeanstalkd\Options\BeanstalkdOptions */
-        $beanstalkdOptions = $this->serviceManager->get('SlmQueueBeanstalkd\Options\BeanstalkdOptions');
+        $beanstalkdOptions = $this->serviceManager->get(BeanstalkdOptions::class);
         $connectionOptions = $beanstalkdOptions->getConnection();
 
-        $this->assertInstanceOf('SlmQueueBeanstalkd\Options\BeanstalkdOptions', $beanstalkdOptions);
-        $this->assertInstanceOf('SlmQueueBeanstalkd\Options\ConnectionOptions', $connectionOptions);
+        $this->assertInstanceOf(BeanstalkdOptions::class, $beanstalkdOptions);
+        $this->assertInstanceOf(ConnectionOptions::class, $connectionOptions);
         $this->assertEquals('0.0.0.0', $connectionOptions->getHost());
         $this->assertEquals(11300, $connectionOptions->getPort());
         $this->assertEquals(2, $connectionOptions->getTimeout());

--- a/tests/SlmQueueBeanstalkdTest/Util/ServiceManagerFactory.php
+++ b/tests/SlmQueueBeanstalkdTest/Util/ServiceManagerFactory.php
@@ -49,9 +49,13 @@ class ServiceManagerFactory
      */
     public static function getServiceManager()
     {
-        $serviceManager = new ServiceManager(new ServiceManagerConfig(
+        $config = new ServiceManagerConfig(
             isset(static::$config['service_manager']) ? static::$config['service_manager'] : array()
-        ));
+        );
+
+        $serviceManager = new ServiceManager();
+        $config->configureServiceManager($serviceManager);
+
         $serviceManager->setService('ApplicationConfig', static::$config);
         $serviceManager->setFactory('ServiceListener', 'Zend\Mvc\Service\ServiceListenerFactory');
 

--- a/tests/SlmQueueBeanstalkdTest/Worker/BeanstalkdWorkerTest.php
+++ b/tests/SlmQueueBeanstalkdTest/Worker/BeanstalkdWorkerTest.php
@@ -3,7 +3,7 @@
 namespace SlmQueueBeanstalkdTest\Worker;
 
 use PHPUnit_Framework_TestCase as TestCase;
-use SlmQueue\Worker\WorkerEvent;
+use SlmQueue\Worker\Event\ProcessJobEvent;
 use SlmQueueBeanstalkd\Worker\BeanstalkdWorker;
 
 class BeanstalkdWorkerTest extends TestCase
@@ -24,7 +24,7 @@ class BeanstalkdWorkerTest extends TestCase
         $job   = $this->getMock('SlmQueue\Job\JobInterface');
 
         $status = $this->worker->processJob($job, $queue);
-        $this->assertEquals(WorkerEvent::JOB_STATUS_UNKNOWN, $status);
+        $this->assertEquals(ProcessJobEvent::JOB_STATUS_UNKNOWN, $status);
     }
 
     public function testDeleteJobOnSuccess()
@@ -40,7 +40,7 @@ class BeanstalkdWorkerTest extends TestCase
               ->with($job);
 
         $status = $this->worker->processJob($job, $queue);
-        $this->assertEquals(WorkerEvent::JOB_STATUS_SUCCESS, $status);
+        $this->assertEquals(ProcessJobEvent::JOB_STATUS_SUCCESS, $status);
     }
 
     public function testDoNotDeleteJobOnFailure()
@@ -56,6 +56,6 @@ class BeanstalkdWorkerTest extends TestCase
               ->method('delete');
 
         $status = $this->worker->processJob($job, $queue);
-        $this->assertEquals(WorkerEvent::JOB_STATUS_FAILURE_RECOVERABLE, $status);
+        $this->assertEquals(ProcessJobEvent::JOB_STATUS_FAILURE_RECOVERABLE, $status);
     }
 }

--- a/tests/TestConfiguration.php.dist
+++ b/tests/TestConfiguration.php.dist
@@ -16,11 +16,18 @@
  * and is licensed under the MIT license. For more information, see
  * <http://www.doctrine-project.org>.
  */
+$modules = array(
+   'SlmQueue',
+   'SlmQueueBeanstalkd',
+);
+
+// With `zendframework/zend-mvc` v3 you have to manually add `Zend\Router` as module to use `RoutePluginManager`
+if (class_exists('Zend\Router\Module')) {
+    $modules[] = 'Zend\Router';
+}
+
 return array(
-    'modules' => array(
-        'SlmQueue',
-        'SlmQueueBeanstalkd'
-    ),
+    'modules' => $modules,
     'module_listener_options' => array(
         'config_glob_paths' => array(
             __DIR__ . '/testing.config.php',


### PR DESCRIPTION
Added support for ZF3 but had to drop PHP 5.3 and PHP 5.4 support.
In addition I've added PHP 7 and PHP 7.1.